### PR TITLE
do not process strings as character arrays

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -89,6 +89,10 @@ function createSanitizeArray(input) {
     // get raw value
     var value = req[input][name];
 
+    if (!_.isArray(value)) {
+      value = [value];
+    }
+
     // if an arg is specified, add the specified arg to all values
     value = !_.isUndefined(arg) ? _.map(value, function(val) {
       return [val, arg] // passing arg as item 2 in the array allows us to pass a regex to validate each item in the array


### PR DESCRIPTION
If a single string was passed into bodyArray(), it would be processed as a character array instead of a single-element array. This resolves this bug.